### PR TITLE
Allow CV link on homepage to be disabled

### DIFF
--- a/_includes/particles-home.html
+++ b/_includes/particles-home.html
@@ -36,7 +36,9 @@
       {% if site.profile.github %}
       <a class="particles-icon" href="{{ site.profile.github }}">{% include svg/github.svg %}</a>
       {% endif %}
+      {% if site.profile.cv != false %}
       <a class="particles-icon" href="cv">{% include svg/cv-circled.svg %}</a>
+      {% endif %}
     </div>
   </div>
   <div class="particles-scroll">


### PR DESCRIPTION
I'm loving the theme, but I do not necessarily want to be forced to put my CV online.

With this change it becomes possible to disable the CV link on the homepage by setting `cv: false` in `_config.yaml`, though the default behavior is kept. The link will always be shown unless this option is set.