### PR TITLE
Remove university

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -1,9 +1,6 @@
 <div class="contact">
   <h2>Contact</h2>
   <ul>
-    <li>University of Jekyll</li>
-    <li>Department of Themes</li>
-    <li>123 Main St, Anytown, USA</li>
     <li><span class="li-icon">{% include svg/pin-alt.svg %}</span><span>{{ site.address }}</span></li>
     <li><span class="li-icon">{% include svg/phone.svg %}</span><span>{{ site.phone }}</span></li>
     <li><span class="li-icon">{% include svg/mail.svg %}</span><a href="mailto:{{ site.author.email }}">{{ site.author.email }}</a></li>


### PR DESCRIPTION
Basically when using the theme - these values are set

![image](https://github.com/user-attachments/assets/1e28bb38-21da-4d1f-ba2c-4c7b965f4458)

As a workaround I manually created the `_includes/contact.html`

### Ai generated:

This pull request updates the contact information display in the `_includes/contact.html` file to use dynamic site variables instead of hardcoded text.

Changes to contact information:

* Replaced hardcoded address, phone number, and email with dynamic variables `site.address`, `site.phone`, and `site.author.email`, respectively, for improved maintainability and consistency.