### PR TITLE
Update /demo/_config.yml

### DIFF
--- a/demo/_config.yml
+++ b/demo/_config.yml
@@ -8,7 +8,6 @@ theme: cvless
 # site settings
 taglong: Jekyll theme for a beautiful online CV
 tagshort: Jekyll theme
-cv: true
 
 # author settings
 author:
@@ -34,6 +33,7 @@ profile:
   stackoverflow: https://stackoverflow.com/users/0000000/username
   medium: https://medium.com/@username
   github: https://github.com/username
+  cv: true
 
 # build settings
 permalink: pretty


### PR DESCRIPTION
Moved "cv" under "profile" to match logic in /_includes/particles-home.html

The current demo _config.yml file contains the line "cv: false" but the particles-home.html in /_includes/ is checking for "site.profile.cv".  This change only moves the "cv" attribute in the demo file to the location referenced by particles-home.html, nested under "profile:", for added clarity.